### PR TITLE
add ability to supersqueeze files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Superview
 
-This is a small Go program that takes a 4:3 aspect ratio video file, and transforms it to a 16:9 video using the  [GoPro SuperView](https://gopro.com/help/articles/question_answer/What-is-SuperView) method. This means that the image is not naively scaled, but a dynamic scaling is applied where the outer areas are stretched more while the center parts stay close to the original aspect rate.
+This is a small Go program that takes a 4:3 aspect ratio video file, and transforms it to a 16:9 video using the [GoPro SuperView](https://gopro.com/help/articles/question_answer/What-is-SuperView) method. This means that the image is not naively scaled, but a dynamic scaling is applied where the outer areas are stretched more while the center parts stay close to the original aspect rate.
 
 This is not a 1-1 copy of the GoPro algorithm, but an attempt to reach similar quality of output using the open-source [FFmpeg](https://ffmpeg.org/) encoder.
 
-Credits for the idea go to *Banelle*, who wrote the [initial (Python) implementation](https://intofpv.com/t-using-free-command-line-sorcery-to-fake-superview).
+Credits for the idea go to _Banelle_, who wrote the [initial (Python) implementation](https://intofpv.com/t-using-free-command-line-sorcery-to-fake-superview).
 
 Here is a quick animation showing the scaling, note how the text in the center stays the same:
 
@@ -12,19 +12,19 @@ Here is a quick animation showing the scaling, note how the text in the center s
 
 ## Requirements
 
-This program requires FFmpeg in your ``PATH``, please install it using one of these ways:
+This program requires FFmpeg in your `PATH`, please install it using one of these ways:
 
-* Linux: install from your local package manager, for example: ``apt instal ffmpeg``
-* Windows: Download from https://ffmpeg.zeranoe.com/builds/
-* macOS: Download from https://ffmpeg.zeranoe.com/builds/ or install using Homebrew: ``brew install ffmpeg``
+- Linux: install from your local package manager, for example: `apt instal ffmpeg`
+- Windows: Download from https://ffmpeg.zeranoe.com/builds/
+- macOS: Download from https://ffmpeg.zeranoe.com/builds/ or install using Homebrew: `brew install ffmpeg`
 
 ## Installation
 
-Download a recent release from the [releases page on GitHub](https://github.com/Niek/superview/releases). Or build from source using ``go build``.
+Download a recent release from the [releases page on GitHub](https://github.com/Niek/superview/releases). Or build from source using `go build`.
 
 ## Usage
 
-To run the program, launch the ``superview`` program with the ``-i`` (input file) parameter. Optionally, you can provide a ``-o`` (output) and ``-b`` (bitrate) parameter. Full usage instructions:
+To run the program, launch the `superview` program with the `-i` (input file) parameter. Optionally, you can provide a `-o` (output) and `-b` (bitrate) parameter. Full usage instructions:
 
 ```
 Usage:
@@ -34,6 +34,7 @@ Application Options:
   -i, --input=FILE         The input video filename
   -o, --output=FILE        The output video filename (default: output.mp4)
   -b, --bitrate=BITRATE    The bitrate in bytes/second to encode in. If not specified, take the same bitrate as the input file
+  -s, --squeeze            Squeeze 4:3 video stretched to 16:9 (e.g. Caddx Tarsier 2.7k60)
 
 Help Options:
   -h, --help               Show this help message

--- a/superview.go
+++ b/superview.go
@@ -22,7 +22,7 @@ var opts struct {
 	Input   string `short:"i" long:"input" description:"The input video filename" value-name:"FILE" required:"true"`
 	Output  string `short:"o" long:"output" description:"The output video filename" value-name:"FILE" required:"false" default:"output.mp4"`
 	Bitrate int    `short:"b" long:"bitrate" description:"The bitrate in bytes/second to encode in. If not specified, take the same bitrate as the input file" value-name:"BITRATE" required:"false"`
-	Squeeze bool   `short:"s" long:"squeeze" description:"Squeeze an already stretched 16:9 video"`
+	Squeeze bool   `short:"s" long:"squeeze" description:"Squeeze 4:3 video stretched to 16:9 (e.g. Caddx Tarsier 2.7k60)"`
 }
 
 func main() {
@@ -98,7 +98,7 @@ func main() {
 	for y := 0; y < outY; y++ {
 		for x := 0; x < outX; x++ {
 			sx := float64(x) - float64(outX-specs.Streams[0].Width)/2.0 // x - width diff/2
-			tx := (float64(x)/float64(outX) - 0.5) * 2.0
+			tx := (float64(x)/float64(outX) - 0.5) * 2.0                // (x/width - 0.5) * 2
 
 			var offset float64
 

--- a/superview.go
+++ b/superview.go
@@ -22,6 +22,7 @@ var opts struct {
 	Input   string `short:"i" long:"input" description:"The input video filename" value-name:"FILE" required:"true"`
 	Output  string `short:"o" long:"output" description:"The output video filename" value-name:"FILE" required:"false" default:"output.mp4"`
 	Bitrate int    `short:"b" long:"bitrate" description:"The bitrate in bytes/second to encode in. If not specified, take the same bitrate as the input file" value-name:"BITRATE" required:"false"`
+	Squeeze bool   `short:"s" long:"squeeze" description:"Squeeze an already stretched 16:9 video"`
 }
 
 func main() {
@@ -71,10 +72,16 @@ func main() {
 		opts.Bitrate, _ = strconv.Atoi(specs.Streams[0].Bitrate)
 	}
 
-	outX := int(float64(specs.Streams[0].Height)*(16.0/9.0)) / 2 * 2 // multiplier of 2
+	var outX int
+
+	if opts.Squeeze {
+		outX = specs.Streams[0].Width
+	} else {
+		outX = int(float64(specs.Streams[0].Height)*(16.0/9.0)) / 2 * 2 // multiplier of 2
+	}
 	outY := specs.Streams[0].Height
 
-	fmt.Printf("Scaling input file %s (codec: %s, duration: %d secs) from %d*%d to %d*%d using superview scaling\n", opts.Input, specs.Streams[0].Codec, int(duration), specs.Streams[0].Width, specs.Streams[0].Height, outX, outY)
+	fmt.Printf("Scaling input file %s (codec: %s, duration: %d secs) from %d*%d to %d*%d using superview scaling. Squeeze: %t\n", opts.Input, specs.Streams[0].Codec, int(duration), specs.Streams[0].Width, specs.Streams[0].Height, outX, outY, opts.Squeeze)
 
 	// Generate PGM P2 files for remap filter, see https://trac.ffmpeg.org/wiki/RemapFilter
 	fX, err := os.Create("x.pgm")
@@ -90,14 +97,32 @@ func main() {
 
 	for y := 0; y < outY; y++ {
 		for x := 0; x < outX; x++ {
-			sx := float64(x) - float64(outX-specs.Streams[0].Width)/2.0              // x - width diff/2
-			tx := (float64(x)/float64(outX) - 0.5) * 2.0                             // (x/width - 0.5) * 2
-			offset := math.Pow(tx, 2) * (float64(outX-specs.Streams[0].Width) / 2.0) // tx^2 * width diff/2
-			if tx < 0 {
-				offset *= -1
+			sx := float64(x) - float64(outX-specs.Streams[0].Width)/2.0 // x - width diff/2
+
+			var offset float64
+
+			if opts.Squeeze {
+				tx := (float64(x)/float64(outX) - 0.5) * 2.0
+				inv := 1 - math.Abs(tx)
+
+				offset = inv*(float64((outX/16)*7)/2.0) - math.Pow((inv/16)*7, 2)*(float64((outX/7)*16)/2.0)
+
+				if tx < 0 {
+					offset *= -1
+				}
+
+				wX.WriteString(strconv.Itoa(int(sx + offset)))
+			} else {
+				tx := (float64(x)/float64(outX) - 0.5) * 2.0                            // (x/width - 0.5) * 2
+				offset = math.Pow(tx, 2) * (float64(outX-specs.Streams[0].Width) / 2.0) // tx^2 * width diff/2
+
+				if tx < 0 {
+					offset *= -1
+				}
+
+				wX.WriteString(strconv.Itoa(int(sx - offset)))
 			}
 
-			wX.WriteString(strconv.Itoa(int(sx - offset)))
 			wX.WriteString(" ")
 
 			wY.WriteString(strconv.Itoa(y))

--- a/superview.go
+++ b/superview.go
@@ -98,11 +98,11 @@ func main() {
 	for y := 0; y < outY; y++ {
 		for x := 0; x < outX; x++ {
 			sx := float64(x) - float64(outX-specs.Streams[0].Width)/2.0 // x - width diff/2
+			tx := (float64(x)/float64(outX) - 0.5) * 2.0
 
 			var offset float64
 
 			if opts.Squeeze {
-				tx := (float64(x)/float64(outX) - 0.5) * 2.0
 				inv := 1 - math.Abs(tx)
 
 				offset = inv*(float64((outX/16)*7)/2.0) - math.Pow((inv/16)*7, 2)*(float64((outX/7)*16)/2.0)
@@ -113,7 +113,6 @@ func main() {
 
 				wX.WriteString(strconv.Itoa(int(sx + offset)))
 			} else {
-				tx := (float64(x)/float64(outX) - 0.5) * 2.0                            // (x/width - 0.5) * 2
 				offset = math.Pow(tx, 2) * (float64(outX-specs.Streams[0].Width) / 2.0) // tx^2 * width diff/2
 
 				if tx < 0 {


### PR DESCRIPTION
Some cameras (for example, the crapfest that is Caddx Tarsier and possibly Orca) spit out 4:3 videos stretched to 16:9. I added ability to supersqueeze those videos.

Provided formula might not be optimal, @Niek can you help me with that?